### PR TITLE
Remove 'on: push' from CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 


### PR DESCRIPTION
The CI workflow configuration has been updated to remove the 'on: push' trigger. This change ensures that the CI pipeline only runs on pull requests to the 'main' branch, reducing unnecessary builds and tests on every push.