### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,54 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        env:
+          VITE_BASE_PATH: /pc12-fuel-calculator/
+        run: yarn build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Quickly determine how much fuel to add or remove for your PC-12. Adjust for ambi
 
 ### Requirements
 
-- Node.js (v14+)
-- npm or pnpm
+- Node.js (v18+)
+- [Corepack](https://nodejs.org/api/corepack.html) enabled (bundled with Node 18+) to use the pinned Yarn version
 
 ### Installation
 
@@ -33,16 +33,17 @@ Quickly determine how much fuel to add or remove for your PC-12. Adjust for ambi
 git clone https://github.com/yourusername/pc12-fuel-calculator.git
 cd pc12-fuel-calculator
 
-# Install dependencies
-pnpm install
-```
+# Enable Corepack for Yarn
+corepack enable
 
-*(Using npm? Run `npm install` instead.)*
+# Install dependencies
+yarn install --frozen-lockfile
+```
 
 ### Development
 
 ```bash
-pnpm run dev
+yarn dev
 ```
 
 Access the app at [http://localhost:5173](http://localhost:5173). Changes appear instantly as you code.
@@ -50,8 +51,8 @@ Access the app at [http://localhost:5173](http://localhost:5173). Changes appear
 ### Build & Preview
 
 ```bash
-pnpm run build
-pnpm run preview
+yarn build
+yarn preview
 ```
 
 Pre-check your production build locally before deploying.
@@ -64,6 +65,14 @@ Pre-check your production build locally before deploying.
 - `src/utils/`: Utility functions for calculations, conversions, and storage.
 - `tailwind.config.js`: Tailwind configuration.
 - `vite.config.ts`: Vite and PWA setup.
+
+## Deployment to GitHub Pages
+
+The repository includes a GitHub Actions workflow that builds the app and deploys the static files to GitHub Pages.
+
+1. Enable GitHub Pages in your repository settings, selecting **GitHub Actions** as the source.
+2. Ensure the `VITE_BASE_PATH` matches your Pages site (defaults to `/pc12-fuel-calculator/`). You can override it in the Actions workflow `env` block if you use a custom path or a user/organization site.
+3. Push to the `main` branch (or trigger the workflow manually). The workflow will build the Vite site, upload the `dist` artifact, and publish it to Pages.
 
 ## Contributing
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,10 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { VitePWA } from 'vite-plugin-pwa';
 
+const basePath = process.env.VITE_BASE_PATH ?? '/pc12-fuel-calculator/';
+
 export default defineConfig({
+  base: basePath,
   plugins: [
     react(),
     VitePWA({


### PR DESCRIPTION
## Summary
- configure the Vite base path so GitHub Pages builds use the correct asset URLs
- add a GitHub Actions workflow that builds the site and deploys it to GitHub Pages
- document Yarn-based setup along with GitHub Pages deployment steps

## Testing
- yarn build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f3459587c832c883e652b7c2b5256)